### PR TITLE
Update from upstream 04.09.2018

### DIFF
--- a/src/ServiceStack.OrmLite.Oracle/OracleSqlExpression.cs
+++ b/src/ServiceStack.OrmLite.Oracle/OracleSqlExpression.cs
@@ -52,6 +52,11 @@ namespace ServiceStack.OrmLite.Oracle
         {
             return base.OrderBy("dbms_random.value");
         }
+
+        protected override PartialSqlString ToLengthPartialString(object arg)
+        {
+            return new PartialSqlString($"LENGTH({arg})");
+        }
     }
 }
 

--- a/src/ServiceStack.OrmLite.SqlServer/SqlServerExpression.cs
+++ b/src/ServiceStack.OrmLite.SqlServer/SqlServerExpression.cs
@@ -29,6 +29,11 @@ namespace ServiceStack.OrmLite.SqlServer
             return base.OrderBy("NEWID()");
         }
 
+        protected override PartialSqlString ToLengthPartialString(object arg)
+        {
+            return new PartialSqlString($"LEN({arg})");
+        }
+
         protected override void ConvertToPlaceholderAndParameter(ref object right)
         {
             var paramName = Params.Count.ToString();

--- a/src/ServiceStack.OrmLite.Sqlite/SqliteExpression.cs
+++ b/src/ServiceStack.OrmLite.Sqlite/SqliteExpression.cs
@@ -76,5 +76,10 @@ namespace ServiceStack.OrmLite.Sqlite
         {
             return base.OrderBy("random()");
         }
+
+        protected override PartialSqlString ToLengthPartialString(object arg)
+        {
+            return new PartialSqlString($"LENGTH({arg})");
+        }
     }
 }

--- a/src/ServiceStack.OrmLite.VistaDB/VistaDBExpression.cs
+++ b/src/ServiceStack.OrmLite.VistaDB/VistaDBExpression.cs
@@ -66,5 +66,10 @@ namespace ServiceStack.OrmLite.VistaDB
                 ? $"substring({quotedColumn}, {startIndex}, {length.Value})"
                 : $"substring({quotedColumn}, {startIndex}, LEN({quotedColumn}) - {startIndex} + 1)";
         }
+
+        protected override PartialSqlString ToLengthPartialString(object arg)
+        {
+            return new PartialSqlString($"LEN({arg})");
+        }
     }
 }

--- a/src/ServiceStack.OrmLite/Expressions/SqlExpression.cs
+++ b/src/ServiceStack.OrmLite/Expressions/SqlExpression.cs
@@ -1815,6 +1815,12 @@ namespace ServiceStack.OrmLite
                     throw new ArgumentException($"Expression '{m}' accesses unsupported property '{m.Member}' of Nullable<T>");
                 }
 
+                if (m.Member.DeclaringType == typeof(string) &&
+                    m.Member.Name == nameof(string.Length))
+                {
+                    return VisitLengthStringProperty(m);
+                }
+
                 if (IsParameterOrConvertAccess(m))
                     return GetMemberExpression(m);
             }
@@ -2460,6 +2466,18 @@ namespace ServiceStack.OrmLite
                 default:
                     throw new NotSupportedException();
             }
+        }
+
+        private object VisitLengthStringProperty(MemberExpression m)
+        {
+            var sql = Visit(m.Expression);
+
+            return ToLengthPartialString(sql);
+        }
+
+        protected virtual PartialSqlString ToLengthPartialString(object arg)
+        {
+            return new PartialSqlString($"CHAR_LENGTH({arg})");
         }
 
         private PartialSqlString BuildConcatExpression(List<object> args)

--- a/tests/ServiceStack.OrmLite.Tests/ExpressionVisitorTests.cs
+++ b/tests/ServiceStack.OrmLite.Tests/ExpressionVisitorTests.cs
@@ -874,6 +874,28 @@ namespace ServiceStack.OrmLite.Tests
             Assert.AreEqual("asdf", text);
         }
 
+        [Test]
+        public void Can_Where_using_StringLengthProperty1()
+        {
+            System.Linq.Expressions.Expression<Func<TestType, bool>> filter = x => x.TextCol.Length == 4;
+            var q = Db.From<TestType>().Where(filter).OrderBy(x => x.Id);
+
+            var target = Db.Select(q);
+            Assert.That(target.Count, Is.EqualTo(2));
+            var text = target[0].TextCol;
+            Assert.AreEqual("asdf", text);
+        }
+
+        [Test]
+        public void Can_Where_using_StringLengthProperty2()
+        {
+            System.Linq.Expressions.Expression<Func<TestType, bool>> filter = x => x.TextCol.Length == 0;
+            var q = Db.From<TestType>().Where(filter).OrderBy(x => x.Id);
+
+            var target = Db.Select(q);
+            Assert.That(target.Count, Is.EqualTo(0));
+        }
+
         private int MethodReturningInt(int val)
         {
             return val;


### PR DESCRIPTION
* Support for Conditional expression in filter

* Fixes for conditional expressions in filter and sorting

* Using GetFieldValue in InsertOnly just like in Insert.

* Change SqliteBoolConverter DbType to Int32

* Unit test for SqliteBoolConverter, InsertOnly

* Fix for parsing static method inside non-static method.

* Just formatting

* Change access modifier to public for method "IsSqlClass"

* Add support for using the Length property of String