### PR TITLE
Update from upstream 05.09.2018

### DIFF
--- a/src/ServiceStack.OrmLite/Expressions/SqlExpression.cs
+++ b/src/ServiceStack.OrmLite/Expressions/SqlExpression.cs
@@ -2471,6 +2471,14 @@ namespace ServiceStack.OrmLite
         private object VisitLengthStringProperty(MemberExpression m)
         {
             var sql = Visit(m.Expression);
+            if (!IsSqlClass(sql))
+            {
+                if (sql == null)
+                    return 0;
+
+                sql = ((string) sql).Length;
+                return sql;
+            }
 
             return ToLengthPartialString(sql);
         }

--- a/tests/ServiceStack.OrmLite.Tests/CustomSqlExpressionTests.cs
+++ b/tests/ServiceStack.OrmLite.Tests/CustomSqlExpressionTests.cs
@@ -91,7 +91,7 @@ namespace ServiceStack.OrmLite.Tests
         }
     }
 
-    public class CustomSqlExpression<T> : SqlExpression<T>
+    public class CustomSqlExpression<T> : SqliteExpression<T>
     {
 
         public CustomSqlExpression(IOrmLiteDialectProvider dialectProvider) : base(dialectProvider)
@@ -551,6 +551,56 @@ namespace ServiceStack.OrmLite.Tests
             System.Linq.Expressions.Expression<Func<WaybillBase, bool>> filter = x => (x.Number > 0 ? x.DecimalVirtProperty : x.Amount) == 10M;
             var q = Db.From<WaybillBase>().Where(filter).Select(x=>x.Name).GroupBy(x => x.Name).Having(x=>x.VirtProperty == "WaybillVirtPropertyValue");
             var target = Db.Column<string>(q);
+            Assert.AreEqual(3, target.Count);
+        }
+
+        [Test]
+        public void Can_Where_using_StringLengthVirtualProperty1()
+        {
+            System.Linq.Expressions.Expression<Func<WaybillBase, bool>> filter = x => x.VirtProperty.Length == 0;
+
+            var q = Db.From<WaybillBase>().Where(filter);
+            var target = Db.Select(q);
+            Assert.AreEqual(0, target.Count);
+        }
+
+        [Test]
+        public void Can_Where_using_StringLengthVirtualProperty2()
+        {
+            System.Linq.Expressions.Expression<Func<WaybillBase, bool>> filter = x => x.VirtProperty.Length == 24;
+
+            var q = Db.From<WaybillBase>().Where(filter);
+            var target = Db.Select(q);
+            Assert.AreEqual(3, target.Count);
+        }
+
+        [Test]
+        public void Can_Where_using_StringLengthVirtualProperty3()
+        {
+            System.Linq.Expressions.Expression<Func<WaybillBase, bool>> filter = x => x.VirtProperty.Length == 0 && x.Id > 0;
+
+            var q = Db.From<WaybillBase>().Where(filter);
+            var target = Db.Select(q);
+            Assert.AreEqual(0, target.Count);
+        }
+
+        [Test]
+        public void Can_Where_using_StringLengthVirtualProperty4()
+        {
+            System.Linq.Expressions.Expression<Func<WaybillBase, bool>> filter = x => x.VirtPropertyNull.Length == 0;
+
+            var q = Db.From<WaybillBase>().Where(filter);
+            var target = Db.Select(q);
+            Assert.AreEqual(3, target.Count);
+        }
+
+        [Test]
+        public void Can_Where_using_StringLengthVirtualProperty5()
+        {
+            System.Linq.Expressions.Expression<Func<WaybillBase, bool>> filter = x => x.VirtPropertyNull.Length == 0 && x.Id > 0;
+
+            var q = Db.From<WaybillBase>().Where(filter);
+            var target = Db.Select(q);
             Assert.AreEqual(3, target.Count);
         }
     }


### PR DESCRIPTION
* Support for Conditional expression in filter

* Fixes for conditional expressions in filter and sorting

* Using GetFieldValue in InsertOnly just like in Insert.

* Change SqliteBoolConverter DbType to Int32

* Unit test for SqliteBoolConverter, InsertOnly

* Fix for parsing static method inside non-static method.

* Just formatting

* Change access modifier to public for method "IsSqlClass"

* Add support for using the Length property of String

* VisitLengthStringProperty fix for CustomSqlExpression